### PR TITLE
TTV-43 change tide_config to accept URL as an env variable

### DIFF
--- a/src/tidecli/tide_config.py
+++ b/src/tidecli/tide_config.py
@@ -2,7 +2,11 @@ import os
 
 # Configuration for the TIM /oauth
 CLIENT_ID = "oauth2_tide"
-TIM_URL = "http://localhost" if os.getenv("DEV") else "https://tim.jyu.fi"
+# Use DEV for localhost development address
+# For the tim url, use default https://tim.jyu.fi if the user does not supply custom url
+TIM_URL = (
+    "http://localhost" if os.getenv("DEV") else os.getenv("URL", "https://tim.jyu.fi")
+)
 AUTH_ENDPOINT = "/oauth/authorize"
 TOKEN_ENDPOINT = "/oauth/token"
 PORT = 8083


### PR DESCRIPTION
Change the TIM_URL variable from tide_config.py to accept URL as environmental variable.
The purpose of this change is to allow VSCode extension to set environmental variables to spawned childprocesses when sending commands to TIDE-CLI. The DEV env variable still operates as before and http://tim.jyu.fi is still used if URL is not given.

Example usage in bash:
$ URL="http://localhost" tide courses