### PR TITLE
Fix the encoding on json.dumps and fix a path comparison

### DIFF
--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -58,7 +58,11 @@ def check_login(jsondata: bool) -> None:
     user = login_handler.get_signed_in_user()
     if not is_logged_in(print_errors=False, print_token_info=False) or not user:
         if jsondata:
-            click.echo(json.dumps({"logged_in": None}, ensure_ascii=False, indent=4).encode("utf-8"))
+            click.echo(
+                json.dumps({"logged_in": None}, ensure_ascii=False, indent=4).encode(
+                    "utf-8"
+                )
+            )
         else:
             click.echo("Not logged in.")
         return
@@ -87,7 +91,9 @@ def login(jsondata: bool) -> None:
         return
     if jsondata:
         click.echo(
-            json.dumps(login_handler.login(jsondata=True), ensure_ascii=False, indent=4).encode("utf-8")
+            json.dumps(
+                login_handler.login(jsondata=True), ensure_ascii=False, indent=4
+            ).encode("utf-8")
         )
     else:
         details = login_handler.login()
@@ -123,7 +129,9 @@ def courses(jsondata: bool) -> None:
     if jsondata:
         # Create JSON object list
         courses_json = [course.model_dump() for course in data]
-        click.echo(json.dumps(courses_json, ensure_ascii=False, indent=4).encode("utf-8"))
+        click.echo(
+            json.dumps(courses_json, ensure_ascii=False, indent=4).encode("utf-8")
+        )
 
 
 @click.group()
@@ -298,7 +306,8 @@ def reset(file_path_string: str, noneditable_sections: bool) -> None:
         raise click.ClickException("Invalid task file")
 
     task_file_contents = next(
-        (x.content for x in task_files if Path(x.file_name).name == file_path.name), None
+        (x.content for x in task_files if Path(x.file_name).name == file_path.name),
+        None,
     )
     if task_file_contents is None:
         raise click.ClickException("File is not part of this task")

--- a/src/tidecli/main.py
+++ b/src/tidecli/main.py
@@ -58,7 +58,7 @@ def check_login(jsondata: bool) -> None:
     user = login_handler.get_signed_in_user()
     if not is_logged_in(print_errors=False, print_token_info=False) or not user:
         if jsondata:
-            click.echo(json.dumps({"logged_in": None}, ensure_ascii=False, indent=4))
+            click.echo(json.dumps({"logged_in": None}, ensure_ascii=False, indent=4).encode("utf-8"))
         else:
             click.echo("Not logged in.")
         return
@@ -69,7 +69,7 @@ def check_login(jsondata: bool) -> None:
                 {"logged_in": user.username},
                 ensure_ascii=False,
                 indent=4,
-            )
+            ).encode("utf-8")
         )
     else:
         click.echo(f"Logged in as {user.username}")
@@ -87,7 +87,7 @@ def login(jsondata: bool) -> None:
         return
     if jsondata:
         click.echo(
-            json.dumps(login_handler.login(jsondata=True), ensure_ascii=False, indent=4)
+            json.dumps(login_handler.login(jsondata=True), ensure_ascii=False, indent=4).encode("utf-8")
         )
     else:
         details = login_handler.login()
@@ -123,7 +123,7 @@ def courses(jsondata: bool) -> None:
     if jsondata:
         # Create JSON object list
         courses_json = [course.model_dump() for course in data]
-        click.echo(json.dumps(courses_json, ensure_ascii=False, indent=4))
+        click.echo(json.dumps(courses_json, ensure_ascii=False, indent=4).encode("utf-8"))
 
 
 @click.group()
@@ -161,7 +161,7 @@ def list_tasks(demo_path: str, jsondata: bool) -> None:
         # Create JSON object list
         # TODO: the json printed contains a ton of unnecessary information
         tasks_json = [t.to_json() for t in tasks]
-        click.echo(json.dumps(tasks_json, ensure_ascii=False, indent=4))
+        click.echo(json.dumps(tasks_json, ensure_ascii=False, indent=4).encode("utf-8"))
 
 
 @task.command(name="points")
@@ -298,7 +298,7 @@ def reset(file_path_string: str, noneditable_sections: bool) -> None:
         raise click.ClickException("Invalid task file")
 
     task_file_contents = next(
-        (x.content for x in task_files if x.file_name == file_path.name), None
+        (x.content for x in task_files if Path(x.file_name).name == file_path.name), None
     )
     if task_file_contents is None:
         raise click.ClickException("File is not part of this task")


### PR DESCRIPTION
This pull request fixes incorrectly encoded click echos that result from json.dumps being in incorrect encoding. The fix changes the encoding to utf-8.

The pull request also fixes task file name comparison in reset function, to be compatible with more complex folder structure.